### PR TITLE
[EN-1432] Making notes from PPTX files searchable

### DIFF
--- a/lib/extractors/pptx.js
+++ b/lib/extractors/pptx.js
@@ -3,6 +3,7 @@ var xpath = require( 'xpath' )
   , yauzl = require( 'yauzl' )
   , util = require( '../util' )
   , slideMatch = /^ppt\/slides\/slide/
+  , noteMatch = /^ppt\/notesSlides\/notesSlide/
   ;
 
 function _compareSlides( a, b ) {
@@ -71,7 +72,7 @@ function extractText( filePath, options, cb ) {
     });
 
     zipfile.on( 'entry', function( entry ) {
-      if ( slideMatch.test( entry.fileName ) ) {
+      if ( slideMatch.test( entry.fileName ) || noteMatch.test( entry.fileName ) ) {
         util.getTextFromZipFile( zipfile, entry, function( err2, text ) {
           var slide = +entry.fileName.replace( 'ppt/slides/slide', '' ).replace( '.xml', '' );
           slides.push({ slide: slide, text: text });


### PR DESCRIPTION
## PR Goals and Notes for Reviewers:
Making the notes from a powerpoint file searchable.

## Changes Proposed in This PR:
The textract library converts a PPTX file into a zip file, and unzips the file. Once this is done, the content from the slides is present in various .xml files and is then extracted by textract.

- Added the `noteMatch` regular expression. This checks the xml files beginning with the filename `notesSlide`, which contain the content from the notes.
- Added a check to remove extra blank lines from appearing. This is to make it consistent with the crawl for Google Slides.

## Things All DEVs (even non-reviewers) Need to Know:
This change will be submitted to the textract's GitHub as well. Once it is submitted and merged into textract, the package.json in kiitecrawler needs to be updated as well.